### PR TITLE
Require skill loading before bankr API calls

### DIFF
--- a/bankr-agent/agents/bankr-agent.md
+++ b/bankr-agent/agents/bankr-agent.md
@@ -90,9 +90,12 @@ Base, Polygon, Ethereum, Unichain, Solana
 ## Workflow
 
 1. **Identify** user need from their request
-2. **Load** the appropriate capability skill for context
-3. **Execute** using `bankr-job-workflow` skill pattern
-4. **Handle errors** with `bankr-error-handling` skill if needed
+2. **REQUIRED: Load** the matching capability skill - this provides the correct prompt format
+3. **Format** the prompt according to the skill's specifications
+4. **Execute** using `bankr-job-workflow` skill pattern
+5. **Handle errors** with `bankr-error-handling` skill if needed
+
+**CRITICAL**: Never call `bankr_agent_submit_prompt` without first loading the relevant skill. Skills contain required formats (e.g., JSON structure for arbitrary transactions).
 
 ## Capabilities Overview
 

--- a/bankr-agent/commands/bankr-agent.md
+++ b/bankr-agent/commands/bankr-agent.md
@@ -5,22 +5,25 @@ argument-hint: [query]
 
 Send the following query to the Bankr API: $ARGUMENTS
 
-Follow the `bankr-job-workflow` skill for execution:
-1. Submit the query using `bankr_agent_submit_prompt`
-2. Poll for status using `bankr_agent_get_job_status` every 2 seconds
-3. Report status updates to the user as they come in
-4. When complete, share the final response
+**IMPORTANT: Before calling any MCP tool, you MUST load the appropriate capability skill to get the correct prompt format.**
 
-For context on specific operations, load the appropriate capability skill:
-- Trading: `bankr-token-trading`
-- Transfers: `bankr-transfers`
-- Polymarket: `bankr-polymarket`
-- Leverage: `bankr-leverage-trading`
-- NFTs: `bankr-nft-operations`
-- Portfolio: `bankr-portfolio`
-- Research: `bankr-market-research`
-- Automation: `bankr-automation`
-- Token deployment: `bankr-token-deployment`
+1. First, identify the operation type and load the matching skill:
+   - Trading (buy/sell/swap): `bankr-token-trading`
+   - Transfers (send to address/ENS/@handle): `bankr-transfers`
+   - Polymarket (bets/odds/positions): `bankr-polymarket`
+   - Leverage (long/short/Avantis): `bankr-leverage-trading`
+   - NFTs (browse/buy): `bankr-nft-operations`
+   - Portfolio (balances/holdings): `bankr-portfolio`
+   - Research (prices/analysis/sentiment): `bankr-market-research`
+   - Automation (limit orders/DCA/stop-loss): `bankr-automation`
+   - Token deployment (Clanker): `bankr-token-deployment`
+   - Raw transactions/calldata/arbitrary tx: `bankr-arbitrary-transaction`
+
+2. Then follow `bankr-job-workflow` for execution:
+   - Submit the query using `bankr_agent_submit_prompt`
+   - Poll for status using `bankr_agent_get_job_status` every 2 seconds
+   - Report status updates to the user as they come in
+   - When complete, share the final response
 
 If errors occur, consult the `bankr-error-handling` skill.
 


### PR DESCRIPTION
## Summary
- Make skill loading mandatory before calling Bankr MCP tools
- Add missing `bankr-arbitrary-transaction` to command skill list
- Add CRITICAL note preventing API calls without loading relevant skill first
- Restructure workflow: identify → load skill → format prompt → execute

## Problem
When a user requested an arbitrary transaction submission, Claude called `bankr_agent_submit_prompt` directly without loading the `bankr-arbitrary-transaction` skill first. This resulted in an incorrectly formatted prompt (natural language instead of the required JSON format).

## Solution
Updated both `agents/bankr-agent.md` and `commands/bankr-agent.md` to make skill loading a **required** step rather than optional guidance. This ensures Claude gets the correct prompt format from the skill before submitting to the API.

## Test plan
- [ ] Submit an arbitrary transaction request and verify Claude loads `bankr-arbitrary-transaction` skill first
- [ ] Verify the prompt uses JSON format as specified in the skill
- [ ] Test other operations (trading, transfers) to ensure skill loading still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)