### PR TITLE
Bump plugin version to 1.1.1

### DIFF
--- a/bankr-agent/.claude-plugin/plugin.json
+++ b/bankr-agent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bankr-agent",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Integration with Bankr API for crypto trading, market analysis, and Polymarket predictions",
   "author": {
     "name": "Bankr Team"


### PR DESCRIPTION
## Summary
- Bump bankr-agent plugin version from 1.1.0 to 1.1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)